### PR TITLE
Fix bug and optimized logic

### DIFF
--- a/Example/Daysquare/Classes/DAYCalendarView.m
+++ b/Example/Daysquare/Classes/DAYCalendarView.m
@@ -355,7 +355,8 @@
         if (self->_currentVisibleRow == 0) {
             NSUInteger paddingDays = [DAYUtils firstWeekdayInMonth:self->_visibleMonth ofYear:self->_visibleYear] - 1;
             
-            self->_currentVisibleRow = floor((day - paddingDays) / 7);
+            float result = (day - paddingDays) / 7;
+            self->_currentVisibleRow = floor(result) == result?(result - 1):floor(result);
         }
     }
     

--- a/Example/Daysquare/Classes/DAYCalendarView.m
+++ b/Example/Daysquare/Classes/DAYCalendarView.m
@@ -350,6 +350,13 @@
         }
         self.todayIndicatorView.attachingView = view;
         [self addConstraintToCenterIndicatorView:self.todayIndicatorView toView:view];
+        
+        // by Rakuyo. Solves the problem that default row is not the current date's row in single line mode
+        if (self->_currentVisibleRow == 0) {
+            NSUInteger paddingDays = [DAYUtils firstWeekdayInMonth:self->_visibleMonth ofYear:self->_visibleYear] - 1;
+            
+            self->_currentVisibleRow = floor((day - paddingDays) / 7);
+        }
     }
     
     view.containingEvent = nil;
@@ -442,19 +449,19 @@
     }];
     
     [self.contentWrapperView addConstraint:[NSLayoutConstraint constraintWithItem:view
-                                                          attribute:NSLayoutAttributeCenterX
-                                                          relatedBy:NSLayoutRelationEqual
-                                                             toItem:toView
-                                                          attribute:NSLayoutAttributeCenterX
-                                                         multiplier:1.0
-                                                           constant:0]];
+                                                                        attribute:NSLayoutAttributeCenterX
+                                                                        relatedBy:NSLayoutRelationEqual
+                                                                           toItem:toView
+                                                                        attribute:NSLayoutAttributeCenterX
+                                                                       multiplier:1.0
+                                                                         constant:0]];
     [self.contentWrapperView addConstraint:[NSLayoutConstraint constraintWithItem:view
-                                                          attribute:NSLayoutAttributeCenterY
-                                                          relatedBy:NSLayoutRelationEqual
-                                                             toItem:toView
-                                                          attribute:NSLayoutAttributeCenterY
-                                                         multiplier:1.0
-                                                           constant:0]];
+                                                                        attribute:NSLayoutAttributeCenterY
+                                                                        relatedBy:NSLayoutRelationEqual
+                                                                           toItem:toView
+                                                                        attribute:NSLayoutAttributeCenterY
+                                                                       multiplier:1.0
+                                                                         constant:0]];
     [view addConstraint:[NSLayoutConstraint constraintWithItem:view
                                                      attribute:NSLayoutAttributeWidth
                                                      relatedBy:NSLayoutRelationEqual
@@ -512,8 +519,16 @@
         return;
     }
     
-    if (self.selectedIndicatorView.hidden) {
-        self.selectedIndicatorView.hidden = NO;
+    // by Rakuyo. Solves the problem that switch error in single line mode
+    if (self.selectedIndicatorView.hidden || self.selectedIndicatorView.alpha == 0) {
+        
+        if (self.selectedIndicatorView.hidden) {
+            self.selectedIndicatorView.hidden = NO;
+        }
+        if (self.selectedIndicatorView.alpha == 0) {
+            self.selectedIndicatorView.alpha = 1;
+        }
+        
         self.selectedIndicatorView.transform = CGAffineTransformMakeScale(0, 0);
         self.selectedIndicatorView.attachingView = sender;
         [self addConstraintToCenterIndicatorView:self.selectedIndicatorView toView:sender];
@@ -572,6 +587,19 @@
     if (self.singleRowMode) {
         if (self->_currentVisibleRow < 5) {
             ++self->_currentVisibleRow;
+            
+            // by Rakuyo. Optimize jump logic
+            NSUInteger totalDays = [DAYUtils daysInMonth:self->_visibleMonth ofYear:self->_visibleYear];
+            NSUInteger paddingDays = [DAYUtils firstWeekdayInMonth:self->_visibleMonth  ofYear:self->_visibleYear] - 1;
+            BOOL flag = (self.componentViews.count - totalDays - paddingDays) >= 7;
+            
+            if (self->_currentVisibleRow == 5 && flag) {
+                ++self->_currentVisibleRow;
+                [self jumpToNextMonth];
+                
+                return;
+            }
+            
             [UIView transitionWithView:self.contentWrapperView duration:0.4 options:UIViewAnimationOptionTransitionFlipFromTop animations:nil completion:nil];
             [self updateCurrentVisibleRow];
             
@@ -609,9 +637,13 @@
             [self updateCurrentVisibleRow];
             
             return;
-        }
-        else {
-            self->_currentVisibleRow = 5;
+        } else {
+            
+            // by Rakuyo. Optimize jump logic
+            NSUInteger totalDays = [DAYUtils daysInMonth:self->_visibleMonth - 1 ofYear:self->_visibleYear];
+            NSUInteger paddingDays = [DAYUtils firstWeekdayInMonth:self->_visibleMonth - 1  ofYear:self->_visibleYear] - 1;
+            
+            self->_currentVisibleRow = ((self.componentViews.count - totalDays - paddingDays) >= 7)?4:5;
         }
     }
     

--- a/Example/Lib/DAYCalendarView.m
+++ b/Example/Lib/DAYCalendarView.m
@@ -355,7 +355,8 @@
         if (self->_currentVisibleRow == 0) {
             NSUInteger paddingDays = [DAYUtils firstWeekdayInMonth:self->_visibleMonth ofYear:self->_visibleYear] - 1;
             
-            self->_currentVisibleRow = floor((day - paddingDays) / 7);
+            float result = (day - paddingDays) / 7;
+            self->_currentVisibleRow = floor(result) == result?(result - 1):floor(result);
         }
     }
     

--- a/Example/Lib/DAYCalendarView.m
+++ b/Example/Lib/DAYCalendarView.m
@@ -350,6 +350,13 @@
         }
         self.todayIndicatorView.attachingView = view;
         [self addConstraintToCenterIndicatorView:self.todayIndicatorView toView:view];
+        
+        // by Rakuyo. Solves the problem that default row is not the current date's row in single line mode
+        if (self->_currentVisibleRow == 0) {
+            NSUInteger paddingDays = [DAYUtils firstWeekdayInMonth:self->_visibleMonth ofYear:self->_visibleYear] - 1;
+            
+            self->_currentVisibleRow = floor((day - paddingDays) / 7);
+        }
     }
     
     view.containingEvent = nil;
@@ -442,19 +449,19 @@
     }];
     
     [self.contentWrapperView addConstraint:[NSLayoutConstraint constraintWithItem:view
-                                                          attribute:NSLayoutAttributeCenterX
-                                                          relatedBy:NSLayoutRelationEqual
-                                                             toItem:toView
-                                                          attribute:NSLayoutAttributeCenterX
-                                                         multiplier:1.0
-                                                           constant:0]];
+                                                                        attribute:NSLayoutAttributeCenterX
+                                                                        relatedBy:NSLayoutRelationEqual
+                                                                           toItem:toView
+                                                                        attribute:NSLayoutAttributeCenterX
+                                                                       multiplier:1.0
+                                                                         constant:0]];
     [self.contentWrapperView addConstraint:[NSLayoutConstraint constraintWithItem:view
-                                                          attribute:NSLayoutAttributeCenterY
-                                                          relatedBy:NSLayoutRelationEqual
-                                                             toItem:toView
-                                                          attribute:NSLayoutAttributeCenterY
-                                                         multiplier:1.0
-                                                           constant:0]];
+                                                                        attribute:NSLayoutAttributeCenterY
+                                                                        relatedBy:NSLayoutRelationEqual
+                                                                           toItem:toView
+                                                                        attribute:NSLayoutAttributeCenterY
+                                                                       multiplier:1.0
+                                                                         constant:0]];
     [view addConstraint:[NSLayoutConstraint constraintWithItem:view
                                                      attribute:NSLayoutAttributeWidth
                                                      relatedBy:NSLayoutRelationEqual
@@ -512,8 +519,16 @@
         return;
     }
     
-    if (self.selectedIndicatorView.hidden) {
-        self.selectedIndicatorView.hidden = NO;
+    // by Rakuyo. Solves the problem that switch error in single line mode
+    if (self.selectedIndicatorView.hidden || self.selectedIndicatorView.alpha == 0) {
+        
+        if (self.selectedIndicatorView.hidden) {
+            self.selectedIndicatorView.hidden = NO;
+        }
+        if (self.selectedIndicatorView.alpha == 0) {
+            self.selectedIndicatorView.alpha = 1;
+        }
+        
         self.selectedIndicatorView.transform = CGAffineTransformMakeScale(0, 0);
         self.selectedIndicatorView.attachingView = sender;
         [self addConstraintToCenterIndicatorView:self.selectedIndicatorView toView:sender];
@@ -572,6 +587,19 @@
     if (self.singleRowMode) {
         if (self->_currentVisibleRow < 5) {
             ++self->_currentVisibleRow;
+            
+            // by Rakuyo. Optimize jump logic
+            NSUInteger totalDays = [DAYUtils daysInMonth:self->_visibleMonth ofYear:self->_visibleYear];
+            NSUInteger paddingDays = [DAYUtils firstWeekdayInMonth:self->_visibleMonth  ofYear:self->_visibleYear] - 1;
+            BOOL flag = (self.componentViews.count - totalDays - paddingDays) >= 7;
+            
+            if (self->_currentVisibleRow == 5 && flag) {
+                ++self->_currentVisibleRow;
+                [self jumpToNextMonth];
+                
+                return;
+            }
+            
             [UIView transitionWithView:self.contentWrapperView duration:0.4 options:UIViewAnimationOptionTransitionFlipFromTop animations:nil completion:nil];
             [self updateCurrentVisibleRow];
             
@@ -609,9 +637,13 @@
             [self updateCurrentVisibleRow];
             
             return;
-        }
-        else {
-            self->_currentVisibleRow = 5;
+        } else {
+            
+            // by Rakuyo. Optimize jump logic
+            NSUInteger totalDays = [DAYUtils daysInMonth:self->_visibleMonth - 1 ofYear:self->_visibleYear];
+            NSUInteger paddingDays = [DAYUtils firstWeekdayInMonth:self->_visibleMonth - 1  ofYear:self->_visibleYear] - 1;
+            
+            self->_currentVisibleRow = ((self.componentViews.count - totalDays - paddingDays) >= 7)?4:5;
         }
     }
     


### PR DESCRIPTION
修复了两个bug，另外还有优化了一个单行模式下的跳转逻辑。

在代码中直接搜索 Rakuyo 可以看到我的修改。

1. 修复 在单行模式下，选中某一个日期后切换周，再次选中任意一个日期后，日期小消失的bug
2. 修复 在单行模式下初始化时，默认显示的不是当前日期行的bug。
3. 优化 在单行模式下的跳转逻辑。切换周时，如果下/上一周属于下/上月份，则直接跳到下/上月份。